### PR TITLE
Include LICENSE

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ autoexamples = false
 
 build = "bindings/rust/build.rs"
 include = [
+  "LICENSE",
   "bindings/rust/*",
   "grammar.js",
   "queries/*",


### PR DESCRIPTION
This is needed by the MIT license terms

```
$ cargo package --list --no-verify | grep LICENSE
LICENSE
```